### PR TITLE
WIP - Improve data extraction method using a static ruleset. Fixes #21.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -8,6 +8,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 browser.runtime.onMessage.addListener((message) => {
   if (message.type === 'product-data') {
+    // TODO: Send this data to the sidebar to be displayed
     console.log(message.data);
   }
 });

--- a/src/product_info.js
+++ b/src/product_info.js
@@ -3,32 +3,98 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-const OpenGraphPropertyValues = {
+const OPEN_GRAPH_PROPERTY_VALUES = {
   title: 'og:title',
   image: 'og:image',
   price: 'og:price:amount',
 };
+const PRODUCT_RECOGNITION_DATA_URL = 'product_recognition_data.json';
+// prd = product recognition data
+let prd;
 
-function getProductData() {
-  const data = {};
-  for (const [key, value] of Object.entries(OpenGraphPropertyValues)) {
-    const metaEle = document.querySelector(`meta[property="${value}"]`);
-    if (metaEle) {
-      data[key] = metaEle.getAttribute('content');
+function init() {
+  const prdUrl = browser.extension.getURL(PRODUCT_RECOGNITION_DATA_URL);
+  getPrd(prdUrl).then((data) => {
+    prd = data;
+    const selectors = getSelectors();
+    const productInfo = getProductInfo(selectors);
+    if (productInfo) {
+      // Note: Can't send HTML elements to background.js; they are not stringify-able
+      browser.runtime.sendMessage({
+        type: 'product-data',
+        data: productInfo,
+      });
+    } else {
+      console.log('No product elements were found for this vendor.');
+    }
+  });
+}
+
+async function getPrd(url) {
+  // 'import' and 'require' not yet supported in WebExtensions
+  let data = await fetch(url);
+  data = await data.json();
+  return data;
+}
+
+function getSelectors() {
+  const hostname = new URL(window.location.href).host;
+  // See if top level key of data blob is a substring in hostname
+  for (const [vendor, selectors] of Object.entries(prd)) {
+    if (hostname.includes(vendor)) {
+      const titleSelector = selectors.title || null;
+      const priceSelector = selectors.price || null;
+      const imageSelector = selectors.image || null;
+      if (titleSelector || priceSelector || imageSelector) {
+        // We have at least one CSS selector for this vendor
+        return {
+          title: titleSelector,
+          price: priceSelector,
+          image: imageSelector,
+        };
+      }
     }
   }
-  // Note: HTML elements are not stringify-able, so can't be sent.
-  browser.runtime.sendMessage({
-    type: 'product-data',
-    data,
-  });
+  return null;
+}
+
+function getProductInfo(selectors) {
+  const data = {};
+  if (!selectors) {
+    // Didn't find an element based on the CSS selectors for this product,
+    // check OpenGraph <meta> tags.
+    for (const [key, value] of Object.entries(OPEN_GRAPH_PROPERTY_VALUES)) {
+      const metaEle = document.querySelector(`meta[property='${value}']`);
+      if (metaEle) {
+        data[key] = metaEle.getAttribute('content');
+      }
+    }
+    return data;
+  }
+
+  for (const selector in selectors) {
+    // avoid iterating over properties inherited through the prototype chain
+    if (Object.prototype.hasOwnProperty.call(selectors, selector)) {
+      const valueArr = selectors[selector];
+      let element = null;
+      for (let i = 0; i < valueArr.length; i++) {
+        const value = valueArr[i];
+        element = document.querySelector(value);
+        if (element) {
+          data[selector] = element.innerText || element.src;
+          break;
+        }
+      }
+    }
+  }
+  return data;
 }
 
 // Make sure page has finished loading, as JS could alter the DOM.
 if (document.readyState === 'complete') {
-  getProductData();
+  init();
 } else {
   window.addEventListener('load', () => {
-    getProductData();
+    init();
   });
 }

--- a/src/product_recognition_data.json
+++ b/src/product_recognition_data.json
@@ -1,0 +1,30 @@
+{
+  "aliexpress": {
+    "title": [".product-name"],
+    "price": [
+      "#j-sku-discount-price > span",
+      "#j-sku-price"
+    ],
+    "image": [".ui-image-viewer-thumb-frame > img"]
+  },
+  "amazon": {
+    "title": "",
+    "price": "",
+    "image": ""
+  },
+  "ebay": {
+    "title": "",
+    "price": "",
+    "image": ""
+  },
+  "google": {
+    "title": "",
+    "price": "",
+    "image": ""
+  },
+  "walmart": {
+    "title": "",
+    "price": "",
+    "image": ""
+  }
+}


### PR DESCRIPTION
This builds off of #6, extending product recognition to also look for product information (title, image and price only so far) in a static dataset, 'product_recognition_data.json'. The fallback is to check Open Graph meta tags. The information is logged to the browser console.

Note: 'product_recognition_data.json is a manually generated set of CSS selectors for a product page by vendor. I will just be looking at 5 of the biggest e-commerce sites around to populate this dataset.

TODO:
* Differentiate product pages from other pages to avoid unnecessary processing and unrelated data extraction (e.g. Open Graph 'titles' are often found on non-product pages)
* Populate the other 4 sites for 'product_recognition_data.json'.