### PR TITLE
Fix #14: Show page action when we detect a product. 

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -4,25 +4,29 @@
 
 const PRODUCT_KEYS = ['title', 'image', 'price'];
 
+// Open the sidebar when the page action is clicked.
+browser.pageAction.onClicked.addListener(() => {
+  browser.sidebarAction.open();
+});
+
 browser.runtime.onConnect.addListener((port) => {
   port.onMessage.addListener((message) => {
     if (message.type === 'product-data') {
+      // If this page contains a product, prep the sidebar and show the
+      // page action icon for opening the sidebar.
       const isProductPage = hasKeys(message.data, PRODUCT_KEYS);
       if (isProductPage) {
         browser.sidebarAction.setPanel({
           panel: getPanelURL(message.data),
           tabId: port.sender.tab.id,
         });
+        browser.pageAction.show(port.sender.tab.id);
       }
     }
   });
   port.postMessage({
     type: 'background-ready',
   });
-});
-
-browser.browserAction.onClicked.addListener(() => {
-  browser.sidebarAction.open();
 });
 
 /**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,8 +17,9 @@
   "background": {
     "scripts": ["background.bundle.js"]
   },
-  "browser_action": {
-    "default_icon": "icon.svg"
+  "page_action": {
+    "default_icon": "icon.svg",
+    "default_title": "Show Shopping Sidebar"
   },
   "content_scripts": [
     {


### PR DESCRIPTION
This is based off of #20, only the last commit is new. It's pretty small, was way easier than I anticipated.

It replaces the browser action with a page action that only shows on pages that contain products. Product detection is a bit delayed right now, so hit a Crate and Barrel product page and be patient.