### PR TITLE
Fix #76: Live update popup with extracted product while open

### DIFF
--- a/src/browser_action/components/BrowserActionApp.jsx
+++ b/src/browser_action/components/BrowserActionApp.jsx
@@ -57,7 +57,7 @@ export default class BrowserActionApp extends React.Component {
 
     browser.runtime.onMessage.addListener((message) => {
       if (message.subject === 'extracted-product') {
-        this.setState({extractedProduct: message.data});
+        this.setState({extractedProduct: message.extractedProduct});
       }
     });
   }


### PR DESCRIPTION
Previously, the extracted product information was only passed by changing the popup's URL, which would only update on closing and re-opening the popup.

Now, when a product is detected on a page, the background script sends a message with extracted product information to the browserAction script, if available, to update and re-render the browserAction popup. This makes it possible for the popup to update while remaining open.

![74-issue](https://user-images.githubusercontent.com/17437436/45578895-06b56d00-b839-11e8-924a-26ab1a4f5f98.gif)
