### PR TITLE
Fix #76 regression caused by PR#123

### DIFF
--- a/src/background/extraction.js
+++ b/src/background/extraction.js
@@ -28,11 +28,20 @@ export function handleExtractedProductData(extractedProduct, sender) {
     return;
   }
 
-  // Update the toolbar icon's URL with the current page's product if we can
   if (sender.tab) {
     const tabId = sender.tab.id;
+
+    // Update the toolbar icon's URL with the current page's product if we can
     const url = new URL(BROWSER_ACTION_URL);
     url.searchParams.set('extractedProduct', JSON.stringify(extractedProduct));
+
+    // Update the toolbar popup while it is open with the current page's product
+    if (sender.tab.active) {
+      browser.runtime.sendMessage({
+        subject: 'extracted-product',
+        extractedProduct,
+      });
+    }
 
     browser.browserAction.setPopup({popup: url.href, tabId});
     browser.browserAction.setBadgeBackgroundColor({color: BADGE_DETECT_BACKGROUND, tabId});


### PR DESCRIPTION
Live updates of the popup were broken in commit 34f860d1554bf63e1fc3 in PR#123 which refactored ./src/background/index.js by breaking it out into different scripts. The block that sent the message with extracted product information from the background script to the browser action script somehow got lost, despite the fact that PR#123 was rebased before merging.