### PR TITLE
Fix #116: Update Undo UI to final design

### DIFF
--- a/src/browser_action/components/ProductCard.css
+++ b/src/browser_action/components/ProductCard.css
@@ -30,10 +30,6 @@
   width: 16px;
 }
 
-.product .prependum .delete {
-  display: none;
-}
-
 .product .prependum .button {
   position: relative;
   left: -8px;
@@ -128,33 +124,4 @@
   object-fit: contain;
   width: 100%;
   height: 100%;
-}
-
-.product.undo {
-  grid-template-columns: 20px auto;
-  grid-template-rows: 20px;
-  height: 40px;
-  white-space: nowrap;
-}
-
-.product.undo .undo-label-wrapper {
-  display: flex;
-  overflow: hidden;
-  color: var(--grey-40);
-}
-
-/* For text-overflow: ellipsis to have the right font color, the parent container's
- * font color must be set to the ellipsis color.
- */
-.product.undo .title-wrapper {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.product.undo .undo-label {
-  color: var(--grey-90);
-}
-
-.product.undo .title::before {
-  content: '\00a0';
 }

--- a/src/browser_action/components/ProductCard.jsx
+++ b/src/browser_action/components/ProductCard.jsx
@@ -74,24 +74,17 @@ export default class ProductCard extends React.Component {
 
     if (product.isDeleted) {
       return (
-        <div className="product undo" onClick={this.handleClickUndo}>
-          <div className="prependum">
-            <img
-              className="icon"
-              src={browser.extension.getURL('/img/undo.svg')}
-              alt="Keep tracking product"
-            />
-          </div>
-          <div className="undo-label-wrapper">
-            <span className="undo-label">Undo Delete</span>
-            <span className="title-wrapper">
-              <span className="title" title={product.title}>({product.title}</span>
-            </span>
-            {/* This closing parenthesis has to be outside of the span.title element,
-            so that it shows up even for long titles that are truncated by an ellipsis */}
-            )
-          </div>
-        </div>
+        <button type="button" className="menu-item undo" onClick={this.handleClickUndo}>
+          <img
+            className="icon"
+            src={browser.extension.getURL('/img/undo.svg')}
+            alt="Keep tracking product"
+          />
+          <span>Undo Delete</span>
+          <span className="sublabel title" title={product.title}>
+            {product.title}
+          </span>
+        </button>
       );
     }
 

--- a/src/browser_action/components/TrackedProductList.css
+++ b/src/browser_action/components/TrackedProductList.css
@@ -4,6 +4,10 @@
 
 /** Listing of currently-tracked products */
 
+.menu-item.track {
+  border-bottom: 1px solid var(--grey-30);
+}
+
 .product-list {
   margin: 0;
   padding: 0;

--- a/src/browser_action/index.css
+++ b/src/browser_action/index.css
@@ -114,15 +114,23 @@ a:focus {
   align-items: center;
   background: transparent;
   border: none;
-  border-bottom: 1px solid var(--grey-30);
   color: var(--grey-90);
   display: flex;
   font-size: 13px;
+  gap: 10px;
   height: 36px;
   justify-content: start;
   line-height: 24px;
   padding: 6px 16px;
   width: 100%;
+  white-space: nowrap;
+}
+
+.menu-item .sublabel {
+  color: var(--grey-40);
+  min-width: 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .menu-item:enabled:hover {
@@ -139,6 +147,5 @@ a:focus {
 
 .menu-item .icon {
   height: 16px;
-  margin-inline-end: 10px;
   width: 16px;
 }


### PR DESCRIPTION
Per a slack discussion with bryanbell, the original mocks for this feature will be updated to use the [Photon Undo icon](https://design.firefox.com/icons/viewer/).