### PR TITLE
Fix #154: Parse Open Graph price string to a number

### DIFF
--- a/src/extraction/open_graph.js
+++ b/src/extraction/open_graph.js
@@ -6,10 +6,33 @@
  * Product extraction via Open Graph tags.
  */
 
+import {parsePrice} from 'commerce/extraction/utils';
+
 const OPEN_GRAPH_PROPERTY_VALUES = {
   title: 'og:title',
   image: 'og:image',
   price: 'og:price:amount',
+};
+
+/** How product information is extracted depends on the feature */
+const FEATURE_DEFAULTS = {
+  getValueFromElement(element) {
+    return element.getAttribute('content');
+  },
+};
+const PRODUCT_FEATURES = {
+  image: {
+    ...FEATURE_DEFAULTS,
+  },
+  title: {
+    ...FEATURE_DEFAULTS,
+  },
+  price: {
+    ...FEATURE_DEFAULTS,
+    getValueFromElement(element) {
+      return parsePrice([element.getAttribute('content')]);
+    },
+  },
 };
 
 /**
@@ -26,7 +49,7 @@ export default function extractProduct() {
       return null;
     }
 
-    extractedProduct[feature] = metaEle.getAttribute('content');
+    extractedProduct[feature] = PRODUCT_FEATURES[feature].getValueFromElement(metaEle);
   }
 
   return extractedProduct;


### PR DESCRIPTION
This is a bit of a moot point for the MVP, since #70 restricts extraction to our five supported sites, none of which make use of Open Graph meta tags, however, that may change, and the fix was quick.

Note: To test this, comment out the other extraction methods in './src/extraction/index.js' and the allowlist check in that file's 'main' function, then visit a Crate and Barrel product page.