### PR TITLE
Provide value for isTracked prop when no product is extracted.

### DIFF
--- a/src/browser_action/components/TrackProductButton.jsx
+++ b/src/browser_action/components/TrackProductButton.jsx
@@ -15,7 +15,7 @@ import {extractedProductShape, isProductTracked} from 'commerce/state/products';
  */
 @connect(
   (state, {extractedProduct}) => ({
-    isTracked: extractedProduct && isProductTracked(state, extractedProduct),
+    isTracked: extractedProduct ? isProductTracked(state, extractedProduct) : false,
   }),
   {
     addProductFromExtracted: productActions.addProductFromExtracted,


### PR DESCRIPTION
React logs a proptype error to the console constantly without this. Apparently `null` isn't a valid value for required props.