### PR TITLE
Fix #112, fix #60: Dismiss price alerts when browser action closes.

### DIFF
--- a/src/background/browser_action.js
+++ b/src/background/browser_action.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Things related to the browser action that have to run in the background
+ * script.
+ * @module
+ */
+
+import store from 'commerce/state';
+import {deactivateAllAlerts} from 'commerce/state/prices';
+import {removeMarkedProducts} from 'commerce/state/products';
+
+/**
+ * Triggered when the browser action panel opens, this registers a handler to
+ * detect when the panel is closed and perform some cleanup.
+ *
+ * Running these state changes in the background script avoids issues with
+ * making state changes or sending messages from a JS context that is being
+ * unloaded.
+ */
+export function handleBrowserActionOpened(message, port) {
+  port.onDisconnect.addListener(() => {
+    store.dispatch(removeMarkedProducts());
+    store.dispatch(deactivateAllAlerts());
+  });
+}

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -10,7 +10,7 @@
  */
 
 import config from 'commerce/config';
-import handleMessage from 'commerce/background/messages';
+import {handleConnect, handleMessage} from 'commerce/background/messages';
 import {handleNotificationClicked, handlePriceAlerts} from 'commerce/background/price_alerts';
 import {handleWebRequest, updatePrices} from 'commerce/background/price_updates';
 import store from 'commerce/state';
@@ -26,8 +26,9 @@ import {registerEvents} from 'commerce/background/telemetry';
     color: await config.get('badgeAlertBackground'),
   });
 
-  // Register centralized message handler
+  // Register centralized message handlers
   browser.runtime.onMessage.addListener(handleMessage);
+  browser.runtime.onConnect.addListener(handleConnect);
 
   // Display price alerts when they are inserted into the state.
   // This includes the initial load from extension storage below.

--- a/src/background/messages.js
+++ b/src/background/messages.js
@@ -17,17 +17,36 @@
  */
 
 import {handleConfigMessage} from 'commerce/config/background';
+import {handleBrowserActionOpened} from 'commerce/background/browser_action';
 import {handleExtractedProductData} from 'commerce/background/extraction';
 
-export const handlers = new Map([
+// sendMessage/onMessage handlers
+
+export const messageHandlers = new Map([
   ['extracted-product', handleExtractedProductData],
   ['config', handleConfigMessage],
 ]);
 
-export default async function handleMessage(message, sender) {
-  if (handlers.has(message.type)) {
-    return handlers.get(message.type)(message, sender);
+export async function handleMessage(message, sender) {
+  if (messageHandlers.has(message.type)) {
+    return messageHandlers.get(message.type)(message, sender);
   }
 
   return undefined;
+}
+
+// connect/port handlers
+
+export const portMessageHandlers = new Map([
+  ['browser-action-opened', handleBrowserActionOpened],
+]);
+
+export function handleConnect(port) {
+  port.onMessage.addListener((portMessage) => {
+    if (portMessageHandlers.has(portMessage.type)) {
+      return portMessageHandlers.get(portMessage.type)(portMessage, port);
+    }
+
+    return undefined;
+  });
 }

--- a/src/browser_action/components/BrowserActionApp.jsx
+++ b/src/browser_action/components/BrowserActionApp.jsx
@@ -12,7 +12,6 @@ import EmptyOnboarding from 'commerce/browser_action/components/EmptyOnboarding'
 import TrackedProductList from 'commerce/browser_action/components/TrackedProductList';
 import {extractedProductShape, getAllProducts, productShape} from 'commerce/state/products';
 import * as syncActions from 'commerce/state/sync';
-import {removeMarkedProducts} from 'commerce/state/products';
 
 import 'commerce/browser_action/components/BrowserActionApp.css';
 
@@ -26,7 +25,6 @@ import 'commerce/browser_action/components/BrowserActionApp.css';
   }),
   {
     loadStateFromStorage: syncActions.loadStateFromStorage,
-    removeMarkedProducts,
   },
 )
 @autobind
@@ -40,7 +38,6 @@ export default class BrowserActionApp extends React.Component {
 
     // Dispatch props
     loadStateFromStorage: pt.func.isRequired,
-    removeMarkedProducts: pt.func.isRequired,
   }
 
   static defaultProps = {
@@ -56,24 +53,12 @@ export default class BrowserActionApp extends React.Component {
 
   componentDidMount() {
     this.props.loadStateFromStorage();
-    window.addEventListener('unload', this.handleUnload);
 
     browser.runtime.onMessage.addListener((message) => {
       if (message.subject === 'extracted-product') {
         this.setState({extractedProduct: message.extractedProduct});
       }
     });
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('unload', this.handleUnload);
-  }
-
-  /**
-   * When the popup closes, delete any products from the store marked for removal.
-   */
-  handleUnload() {
-    this.props.removeMarkedProducts();
   }
 
   /**

--- a/src/browser_action/index.jsx
+++ b/src/browser_action/index.jsx
@@ -26,3 +26,9 @@ ReactDOM.render(
   </Provider>,
   document.getElementById('browser-action-app'),
 );
+
+// Notify the background script that the browser action has been opened. This
+// must be done using connect so that the background script can detect when the
+// panel closes.
+const port = browser.runtime.connect();
+port.postMessage({type: 'browser-action-opened'});

--- a/src/state/prices.js
+++ b/src/state/prices.js
@@ -95,6 +95,7 @@ class PriceWrapper {
 
 const ADD_PRICE = 'commerce/prices/ADD_PRICE';
 const ADD_PRICE_ALERT = 'commerce/prices/ADD_PRICE_ALERT';
+const DEACTIVATE_ALL_PRICE_ALERTS = 'commerce/prices/DEACTIVATE_ALL_PRICE_ALERTS';
 const DEACTIVATE_PRICE_ALERT = 'commerce/prices/DEACTIVATE_PRICE_ALERT';
 const SHOW_PRICE_ALERT = 'commerce/prices/SHOW_PRICE_ALERT';
 
@@ -173,6 +174,15 @@ export default function reducer(state = initialState(), action) {
       };
     }
 
+    case DEACTIVATE_ALL_PRICE_ALERTS: {
+      return {
+        ...state,
+        priceAlerts: state.priceAlerts.map(
+          alert => ({...alert, active: false}),
+        ),
+      };
+    }
+
     default: {
       return state;
     }
@@ -223,6 +233,10 @@ export function deactivateAlert(alert) {
     type: DEACTIVATE_PRICE_ALERT,
     priceId: alert.priceId,
   };
+}
+
+export function deactivateAllAlerts() {
+  return {type: DEACTIVATE_ALL_PRICE_ALERTS};
 }
 
 // Selectors


### PR DESCRIPTION
Switch to using a messaging port disconnect to detect when the browser action
closes. Without this, dismissing price alerts is not consistent as the JS
context for the browser action is unloaded before the async work of updating
the store is finished.

Because we are no longer performing async work after the browser action unloads,
we no longer see the errors from #60 about promises resolving after the context
is destroyed.