### PR TITLE
Fix #187: Limit add-on to Firefox 63.0 and higher.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,8 @@
   "applications": {
     "gecko": {
       "id": "shopping-testpilot@mozilla.org",
-      "update_url": "https://testpilot.firefox.com/files/shopping-testpilot@mozilla.org/updates.json"
+      "update_url": "https://testpilot.firefox.com/files/shopping-testpilot@mozilla.org/updates.json",
+      "strict_min_version": "63.0"
     }
   },
   "icons": {


### PR DESCRIPTION
Tested via `about:debugging` on Release and Beta.