### PR TITLE
Catch connection error for extracted product popup updates

### DIFF
--- a/src/background/extraction.js
+++ b/src/background/extraction.js
@@ -41,12 +41,16 @@ export async function handleExtractedProductData(message, sender) {
     const url = new URL(await config.get('browserActionUrl'));
     url.searchParams.set('extractedProduct', JSON.stringify(extractedProduct));
 
-    // Update the toolbar popup while it is open with the current page's product
+    // Update the toolbar popup if it is open with the current page's product
     if (sender.tab.active) {
-      browser.runtime.sendMessage({
-        subject: 'extracted-product',
-        extractedProduct,
-      });
+      try {
+        await browser.runtime.sendMessage({
+          subject: 'extracted-product',
+          extractedProduct,
+        });
+      } catch (error) {
+        // Popup must be closed
+      }
     }
 
     browser.browserAction.setPopup({popup: url.href, tabId});


### PR DESCRIPTION
If the popup is closed when extraction completes on a page, the background script tries to send a message to the popup to update it, which results in an error:
```
Error: Could not establish connection. Receiving end does not exist.
```

This patch simply catches that error, so that we don't see it in the browser console.