### PR TITLE
Check for background update status in a way that cannot be spoofed.

### DIFF
--- a/src/background/price_updates.js
+++ b/src/background/price_updates.js
@@ -66,9 +66,7 @@ async function fetchLatestPrice(product, delay) {
   }
 
   const iframe = document.createElement('iframe');
-  const url = new URL(product.url);
-  url.hash = 'moz-commerce-background';
-  iframe.src = url.href;
+  iframe.src = product.url;
   iframe.id = product.id;
   // Desktop viewport dimensions (in px) on which Fathom proximity rules are based
   iframe.width = 1680;

--- a/src/extraction/index.js
+++ b/src/extraction/index.js
@@ -70,7 +70,9 @@ async function attemptExtraction() {
   // If we're in an iframe, don't bother extracting a product EXCEPT if we were
   // started by the background script for a price check.
   const isInIframe = window !== window.top;
-  const isBackgroundUpdate = window.location.hash === '#moz-commerce-background';
+  const isBackgroundUpdate = window.top.location.href.startsWith(
+    browser.runtime.getURL('/'), // URL is unique per-install / hard to forge
+  );
   if (isInIframe && !isBackgroundUpdate) {
     return;
   }


### PR DESCRIPTION
Unlike the URL hash, guessing the extension ID and spoofing that at the start
of the page URL shouldn't be possible.

I've opted not to remove the normalization of product URLs that removes url hashes, which was added to accommodate the URL hash change that's being removed. None of our approved sites use them to identify products, so it shouldn't be a problem.