### PR TITLE
Fix #192: Resend product info on subframe load for Walmart/Home Depot.

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -61,6 +61,21 @@ import {registerEvents} from 'commerce/telemetry/extension';
     ['blocking', 'responseHeaders'],
   );
 
+  // Workaround for bug 1493470: Resend product info when subframe loads
+  // accidentally clear the browser action URL.
+  // TODO(osmose): Remove once Firefox 64 hits the release channel.
+  browser.webRequest.onCompleted.addListener((details) => {
+    if (details.tabId) {
+      browser.tabs.sendMessage(details.tabId, {type: 'resend-product'});
+    }
+  }, {
+    urls: [
+      '*://*.walmart.com/*',
+      '*://*.homedepot.com/*',
+    ],
+    types: ['sub_frame'],
+  });
+
   // Make sure the store is loaded before we check prices.
   await store.dispatch(loadStateFromStorage());
 


### PR DESCRIPTION
About the most elegant fix I could come up with given webextension APIs. This fixes the issue of the popup URL being reset by triggering the background script logic of detecting a product on the page whenever a subframe load completes on the two affected domains.

We only save new prices when the price has changed, which makes resending the product info to the background script pretty safe as we won't be saving extra data to the store.