### PR TITLE
Fix #208: Rename add-on to Price Wise.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Price Scout
+# Price Wise
 
-Price Scout is a Firefox extension that tracks price changes to help you find the best time to buy.
+Price Wise is a Firefox extension that tracks price changes to help you find the best time to buy.
 
 ## Developer Setup
 
@@ -11,8 +11,8 @@ Prerequisites:
 1. Clone the repository:
 
    ```sh
-   git clone https://github.com/mozilla/price-scout.git
-   cd price-scout
+   git clone https://github.com/mozilla/price-wise.git
+   cd price-wise
    ```
 2. Install dependencies:
 
@@ -50,7 +50,7 @@ With these installed, you can set up the test suite:
 2. Save the path to your Firefox binary with `npm`:
 
    ```sh
-   npm config set price-scout:firefox_bin <PATH_TO_FIREFOX_BINARY>
+   npm config set price-wise:firefox_bin <PATH_TO_FIREFOX_BINARY>
    ```
 
 After this, you can run `pipenv run test` to run the automated test suite.

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -14,7 +14,7 @@ A summary of the metrics the Price Alerts extension will record.
 * **Price Alert**: An alert that occurs when a tracked product's price _decreases_ below a certain absolute or percentage threshold. For the MVP, the default thresholds are specified in `./src/config.js`.
 * **Product Card**: A product list item in the list of tracked products for which the user has opted to receive Price Alerts displayed on the browserAction popup. Each Product Card displays the product title, image and price among other information.
 * **Product Page**: A webpage ([example](https://www.amazon.com/LEGO-Fantastic-Beasts-Grindelwald-Grindelwalds/dp/B07BKQXCZR/ref=sr_1_3_sspa?s=toys-and-games&ie=UTF8&qid=1538418041&sr=1-3-spons&keywords=legos&psc=1)) displaying a single product that the user could purchase online.
-* **Supported Sites**: For the initial launch (a.k.a. MVP, Minimum Viable Product) of this extension, we are limiting the sites supported by this feature to [five websites](https://github.com/mozilla/price-scout/issues/36#issuecomment-409641491): Amazon, Ebay, Walmart, Home Depot and Best Buy.
+* **Supported Sites**: For the initial launch (a.k.a. MVP, Minimum Viable Product) of this extension, we are limiting the sites supported by this feature to [five websites](https://github.com/mozilla/price-wise/issues/36#issuecomment-409641491): Amazon, Ebay, Walmart, Home Depot and Best Buy.
 * **Survey**: a short survey collecting user feedback.
 * **Onboarding Popup**: The popup displayed when the user has zero products tracked, including the first time the popup is opened.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "price-scout",
+  "name": "price-wise",
   "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "price-scout",
+  "name": "price-wise",
   "version": "5.0.0",
   "description": "",
   "private": "true",

--- a/src/browser_action/components/BrowserActionApp.jsx
+++ b/src/browser_action/components/BrowserActionApp.jsx
@@ -100,7 +100,7 @@ export default class BrowserActionApp extends React.Component {
               alt="Send Feedback"
             />
           </button>
-          <h1 className="title">Price Scout</h1>
+          <h1 className="title">Price Wise</h1>
           <button
             className="ghost help button"
             type="button"

--- a/src/browser_action/index.html
+++ b/src/browser_action/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8">
-    <title>Price Scout</title>
+    <title>Price Wise</title>
   </head>
   <body>
     <div id="browser-action-app"></div>

--- a/src/config.js
+++ b/src/config.js
@@ -76,7 +76,7 @@ const CONFIG = {
   supportUrl: new StringValue('https://support.mozilla.org/kb/new-test-pilot-experiments'),
 
   /** URL for the add-on's feedback form */
-  feedbackUrl: new StringValue('https://www.surveygizmo.com/s3/4649085/Price-Scout-Feedback'),
+  feedbackUrl: new StringValue('https://www.surveygizmo.com/s3/4649085/Price-Wise-Feedback'),
 
   /** List of domains that extraction is performed on. */
   extractionAllowlist: new ListValue([

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "Price Scout",
+  "name": "Price Wise",
   "version": "$version",
   "description": "",
   "applications": {
@@ -22,7 +22,7 @@
       "16": "img/shopping_list.svg",
       "32": "img/shopping_list.svg"
     },
-    "default_title": "Price Scout",
+    "default_title": "Price Wise",
     "default_popup": "browser_action/index.html"
   },
   "permissions": [


### PR DESCRIPTION
![](https://i.imgflip.com/2ky244.jpg)