### PR TITLE
Fix #192: Resend product data after a delay to reset toolbar icon. 

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -64,21 +64,6 @@ import {registerEvents, handleWidgetRemoved} from 'commerce/telemetry/extension'
     ['blocking', 'responseHeaders'],
   );
 
-  // Workaround for bug 1493470: Resend product info when subframe loads
-  // accidentally clear the browser action URL.
-  // TODO(osmose): Remove once Firefox 64 hits the release channel.
-  browser.webRequest.onCompleted.addListener((details) => {
-    if (details.tabId) {
-      browser.tabs.sendMessage(details.tabId, {type: 'resend-product'});
-    }
-  }, {
-    urls: [
-      '*://*.walmart.com/*',
-      '*://*.homedepot.com/*',
-    ],
-    types: ['sub_frame'],
-  });
-
   // Make sure the store is loaded before we check prices.
   await store.dispatch(loadStateFromStorage());
 

--- a/src/extraction/index.js
+++ b/src/extraction/index.js
@@ -109,10 +109,10 @@ async function attemptExtraction() {
     extractedProduct = await attemptExtraction();
   });
 
-  // Re-send the extracted product to the background script if requested
-  browser.runtime.onMessage.addListener(async (message) => {
-    if (message.type === 'resend-product' && extractedProduct) {
-      await sendProductToBackground(extractedProduct);
-    }
-  });
+  // Messy workaround for bug 1493470: Resend product info to the background
+  // script twice in case subframe loads clear the toolbar icon.
+  // TODO(osmose): Remove once Firefox 64 hits the release channel.
+  const resend = () => sendProductToBackground(extractedProduct);
+  setTimeout(resend, 5000);
+  setTimeout(resend, 10000);
 }());


### PR DESCRIPTION
Forgive me father for I have sinned

In my defense, this is much more reliable than any other way I could find of detecting this error. There's still a possibility of very long page loads causing the toolbar icon to be reset after the timers go off, but that's just life. And 64 and above aren't affected by this bug anyway, so it's a temporary pain.

Also I noticed an error being logged to the console a bunch while trying to fix this and included a fix for that too.