### PR TITLE
Change name to Price Tracker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run:
           name: Store XPI name in environment variable
           command: |
-            echo 'export XPI_NAME=price_wise-${CIRCLE_TAG:1}' >> $BASH_ENV
+            echo 'export XPI_NAME=price_tracker-${CIRCLE_TAG:1}' >> $BASH_ENV
       - run:
           name: Install dependencies
           command: |
@@ -77,7 +77,7 @@ jobs:
       - run:
           name: Store XPI name in environment variable
           command: |
-            echo 'export XPI_NAME=price_wise-${CIRCLE_TAG:1}' >> $BASH_ENV
+            echo 'export XPI_NAME=price_tracker-${CIRCLE_TAG:1}' >> $BASH_ENV
       - run:
           name: Install dependencies
           command: |

--- a/.circleci/deploy_addon.sh
+++ b/.circleci/deploy_addon.sh
@@ -9,7 +9,7 @@ set -e
 
 ADDON_ID="shopping-testpilot@mozilla.org"
 ADDON_VERSION=${CIRCLE_TAG:1}
-ADDON_FILE="web-ext-artifacts/price_wise-${ADDON_VERSION}-signed.xpi"
+ADDON_FILE="web-ext-artifacts/price_tracker-${ADDON_VERSION}-signed.xpi"
 test -f $ADDON_FILE
 
 MAX_AGE=30 # We can up this at some point, but keeping it low while we work out the kinks

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Price Wise
+# Price Tracker
 
-Price Wise is a Firefox extension that tracks price changes to help you find the best time to buy.
+Price Tracker is a Firefox extension that tracks price changes to help you find the best time to buy.
 
 
 ## Data Collection
@@ -17,8 +17,8 @@ Prerequisites:
 1. Clone the repository:
 
    ```sh
-   git clone https://github.com/mozilla/price-wise.git
-   cd price-wise
+   git clone https://github.com/mozilla/price-tracker.git
+   cd price-tracker
    ```
 2. Install dependencies:
 
@@ -97,7 +97,7 @@ With these installed, you can set up the test suite:
 2. Save the path to your Firefox binary with `npm`:
 
    ```sh
-   npm config set price-wise:firefox_bin <PATH_TO_FIREFOX_BINARY>
+   npm config set price-tracker:firefox_bin <PATH_TO_FIREFOX_BINARY>
    ```
 
 After this, you can run `pipenv run test` to run the automated test suite.
@@ -132,12 +132,12 @@ The following preferences can be set to customize the extension's behavior for t
 
 ## Releasing a New Version
 
-Price Wise bumps the major version number for every release, similar to Firefox. Releases are created by tagging a commit that bumps the version number and pushing that tag to the repo. This triggers CircleCI automation that packages, tests, signs and uploads the new version to the Test Pilot S3 bucket.
+Price Tracker bumps the major version number for every release, similar to Firefox. Releases are created by tagging a commit that bumps the version number and pushing that tag to the repo. This triggers CircleCI automation that packages, tests, signs and uploads the new version to the Test Pilot S3 bucket.
 
 It is strongly recommended that developers creating releases [configure Git to
 sign their commits and tags][signing].
 
-To create a new release of Price Wise:
+To create a new release of Price Tracker:
 
 1. Increment the version number in `package.json`, create a new commit on the `master` branch with this change, and create a new git tag pointing to the commit with a name of the form `v1.0.0`, where `1.0.0` is the new version number.
 
@@ -146,7 +146,7 @@ To create a new release of Price Wise:
    ```sh
    npm version major
    ```
-2. Push the updated `master` branch and the new tag to the remote for the Mozilla Price Wise repository (named `origin` in the example below):
+2. Push the updated `master` branch and the new tag to the remote for the Mozilla Price Tracker repository (named `origin` in the example below):
 
    ```sh
    git push origin master

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -3,7 +3,7 @@
 
 # Metrics
 
-A summary of the metrics the Price Wise extension will record.
+A summary of the metrics the Price Tracker extension will record.
 
 
 ## Definitions
@@ -14,14 +14,14 @@ A summary of the metrics the Price Wise extension will record.
 * **Price Alert**: An alert that occurs when a tracked product's price _decreases_ below a certain absolute or percentage threshold. For the MVP, the default thresholds are specified in `./src/config.js`.
 * **Product Card**: A product list item in the list of tracked products for which the user has opted to receive Price Alerts displayed on the browserAction popup. Each Product Card displays the product title, image and price among other information.
 * **Product Page**: A webpage displaying a single product that the user could purchase online.
-* **Supported Sites**: For the initial launch (a.k.a. MVP, Minimum Viable Product) of this extension, we are limiting the sites supported by this feature to [five websites](https://github.com/mozilla/price-wise/issues/36#issuecomment-409641491): Amazon, eBay, Walmart, Home Depot and Best Buy.
+* **Supported Sites**: For the initial launch (a.k.a. MVP, Minimum Viable Product) of this extension, we are limiting the sites supported by this feature to [five websites](https://github.com/mozilla/price-tracker/issues/36#issuecomment-409641491): Amazon, eBay, Walmart, Home Depot and Best Buy.
 * **Survey**: a short survey collecting user feedback.
 * **Onboarding Popup**: The popup displayed when the user has zero products tracked, including the first time the popup is opened.
 
 
 ## Analysis
 
-Data collected by the Price Wise extension will be used to answer the following questions:
+Data collected by the Price Tracker extension will be used to answer the following questions:
 
 Note: For any questions related to general user shopping behavior, the data about what sites users visit is limited to the Supported Sites for the MVP.
 
@@ -215,7 +215,7 @@ Some `extra_keys` are sent with every telemetry event recorded by the extension:
 
 ### `open_popup`
 
-Fired when the user clicks the Price Wise browserAction toolbar button to open the popup.
+Fired when the user clicks the Price Tracker browserAction toolbar button to open the popup.
 
 #### Payload properties
 - `methods`: String

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -15,7 +15,6 @@ A summary of the metrics the Price Tracker extension will record.
 * **Product Card**: A product list item in the list of tracked products for which the user has opted to receive Price Alerts displayed on the browserAction popup. Each Product Card displays the product title, image and price among other information.
 * **Product Page**: A webpage displaying a single product that the user could purchase online.
 * **Supported Sites**: For the initial launch (a.k.a. MVP, Minimum Viable Product) of this extension, we are limiting the sites supported by this feature to [five websites](https://github.com/mozilla/price-tracker/issues/36#issuecomment-409641491): Amazon, eBay, Walmart, Home Depot and Best Buy.
-* **Survey**: a short survey collecting user feedback.
 * **Onboarding Popup**: The popup displayed when the user has zero products tracked, including the first time the popup is opened.
 
 
@@ -195,7 +194,6 @@ Some `extra_keys` are sent with every telemetry event recorded by the extension:
   - `'amazon_smile_link'`: Sends the user to AmazonSmile.
   - `'best_buy_link'`: Sends the user to Best Buy.
   - `'ebay_link'`: Sends the user to eBay.
-  - `'feedback_button'`: Sends the user to a feedback Survey.
   - `'home_depot_link'`: Sends the user to Home Depot.
   - `'walmart_link'`: Sends the user to Walmart.
 - `'extraction_id'`: A unique identifier to associate an extraction attempt to an extraction completion event for a given page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "price-wise",
+  "name": "price-tracker",
   "version": "21.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -5746,7 +5746,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5767,12 +5768,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5787,17 +5790,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5914,7 +5920,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5926,6 +5933,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5940,6 +5948,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5947,12 +5956,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5971,6 +5982,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6051,7 +6063,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6063,6 +6076,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6148,7 +6162,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6184,6 +6199,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6203,6 +6219,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6246,12 +6263,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "price-wise",
+  "name": "price-tracker",
   "version": "21.0.0",
-  "description": "Price Wise is a Firefox extension that tracks price changes to help you find the best time to buy.",
+  "description": "Price Tracker is a Firefox extension that tracks price changes to help you find the best time to buy.",
   "private": true,
   "author": "Mozilla",
   "license": "MPL-2.0",
@@ -65,11 +65,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mozilla/price-wise.git"
+    "url": "https://github.com/mozilla/price-tracker.git"
   },
   "keywords": [],
   "bugs": {
-    "url": "https://github.com/mozilla/price-wise/issues"
+    "url": "https://github.com/mozilla/price-tracker/issues"
   },
-  "homepage": "https://github.com/mozilla/price-wise"
+  "homepage": "https://github.com/mozilla/price-tracker"
 }

--- a/src/browser_action/components/BrowserActionApp.css
+++ b/src/browser_action/components/BrowserActionApp.css
@@ -12,12 +12,6 @@
   padding: 0 8px;
 }
 
-.title-bar .feedback {
-  position: absolute;
-  top: 5px;
-  left: 5px;
-}
-
 .title-bar .title {
   font-size: 13px;
   font-weight: bold;

--- a/src/browser_action/components/BrowserActionApp.jsx
+++ b/src/browser_action/components/BrowserActionApp.jsx
@@ -71,15 +71,6 @@ export default class BrowserActionApp extends React.Component {
   }
 
   /**
-   * Open the feedback page and close the panel when the help icon is clicked.
-   */
-  async handleClickFeedback() {
-    browser.tabs.create({url: await config.get('feedbackUrl')});
-    await recordEvent('open_nonproduct_page', 'ui_element', null, {element: 'feedback_button'});
-    window.close();
-  }
-
-  /**
    * Show the Study popup when the StudyFooter is clicked
    */
   handleClickStudy() {
@@ -116,18 +107,6 @@ export default class BrowserActionApp extends React.Component {
     return (
       <React.Fragment>
         <div className="title-bar">
-          <button
-            className="ghost feedback button"
-            type="button"
-            onClick={this.handleClickFeedback}
-            title="Send Feedback"
-          >
-            <img
-              className="icon"
-              src={browser.extension.getURL('img/feedback.svg')}
-              alt="Send Feedback"
-            />
-          </button>
           <h1 className="title">Products</h1>
         </div>
         {products.length < 1

--- a/src/browser_action/components/EmptyOnboarding.jsx
+++ b/src/browser_action/components/EmptyOnboarding.jsx
@@ -58,10 +58,10 @@ export default class EmptyOnboarding extends React.Component {
           {' '}<a data-telemetry-id="ebay" href="https://www.ebay.com/">eBay</a>,
           {' '}<a data-telemetry-id="home_depot" href="https://www.homedepot.com/">Home Depot</a> and
           {' '}<a data-telemetry-id="walmart" href="https://www.walmart.com/">Walmart</a>
-          {' '}(U.S. domains only for now). When Price Wise finds a price drop, the add-on gives you a heads-up about the lower price.
+          {' '}(U.S. domains only for now). When Price Tracker finds a price drop, the add-on gives you a heads-up about the lower price.
         </p>
         <p className="description">
-          Price Wise keeps track of your saved products by occasionally loading their webpages in
+          Price Tracker keeps track of your saved products by occasionally loading their webpages in
           the background while Firefox is open.
         </p>
         <TrackProductButton className="button" extractedProduct={extractedProduct} />

--- a/src/browser_action/components/StudyFooter.jsx
+++ b/src/browser_action/components/StudyFooter.jsx
@@ -25,7 +25,7 @@ export default class StudyFooter extends React.Component {
         className="menu-item study"
         onClick={this.props.onClick}
       >
-      Help us improve Price Wise&hellip;
+      Help us improve Price Tracker&hellip;
       </button>
     );
   }

--- a/src/browser_action/components/StudyInvitation.jsx
+++ b/src/browser_action/components/StudyInvitation.jsx
@@ -40,7 +40,7 @@ export default class StudyInvitation extends React.Component {
         <div className="study-invitation">
           <img className="hero" src={browser.extension.getURL('img/ur_survey.svg')} alt="" />
           <p className="description">
-            {"Help us improve Price Wise by participating in a research study. Take this 5-minute survey to learn more about the study and see if you're a fit."}
+            {"Help us improve Price Tracker by participating in a research study. Take this 5-minute survey to learn more about the study and see if you're a fit."}
           </p>
           <button
             className="button participate"

--- a/src/browser_action/index.html
+++ b/src/browser_action/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8">
-    <title>Price Wise</title>
+    <title>Price Tracker</title>
   </head>
   <body>
     <div id="browser-action-app"></div>

--- a/src/config.js
+++ b/src/config.js
@@ -72,9 +72,6 @@ const CONFIG = {
   /** Color of the toolbar badge when a product on the current page is trackable. */
   badgeDetectBackground: new StringValue('#33F70C'),
 
-  /** URL for the add-on's feedback form */
-  feedbackUrl: new StringValue('https://qsurvey.mozilla.com/s3/price-wise'),
-
   /** List of domains that extraction is performed on. */
   extractionAllowlist: new ListValue([
     'amazon.com',

--- a/src/img/feedback.svg
+++ b/src/img/feedback.svg
@@ -1,6 +1,0 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg data-name="Flat (For Export)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-  <path fill="context-fill" fill-opacity="context-fill-opacity" d="M15.93 14.24l-2-3.37A5.75 5.75 0 0 0 15 7.5C15 3.91 11.64 1 7.5 1S0 3.91 0 7.5 3.36 14 7.5 14a8.47 8.47 0 0 0 3.13-.6l4.71 1.6a.45.45 0 0 0 .16 0 .51.51 0 0 0 .39-.19.5.5 0 0 0 .04-.57zM3.5 9A1.5 1.5 0 1 1 5 7.5 1.5 1.5 0 0 1 3.5 9zm4 0A1.5 1.5 0 1 1 9 7.5 1.5 1.5 0 0 1 7.5 9zm4 0A1.5 1.5 0 1 1 13 7.5 1.5 1.5 0 0 1 11.5 9z"/>
-</svg>

--- a/src/intro.html
+++ b/src/intro.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8">
-    <title>Price Wise by Mozilla</title>
+    <title>Price Tracker by Mozilla</title>
     <style>
       :root {
         --blue-50: #0a84ff;
@@ -104,19 +104,19 @@
   <body>
     <h1 class="title">
       <span class="icon"><img src="/img/shopping_list.svg"></span>
-      Price Wise
+      Price Tracker
     </h1>
     <section class="privacy">
       <h2>Your Privacy</h2>
-      <p>We care about your privacy. Price Wise collects some information about your use of the add-on:</p>
+      <p>We care about your privacy. Price Tracker collects some information about your use of the add-on:</p>
       <ul>
-        <li><b>Product Pages:</b> Price Wise collects how often you visit saved product pages.</li>
-        <li><b>Product Data:</b> Price Wise collects data about the products you choose to track such as prices change frequency, size, and the accuracy of that information.</li>
-        <li><b>Interaction Data:</b> Price Wise collects information about how you use the feature such as how often you add, delete and interact with saved products, number of products you choose to track, and how you engage with messages and push notifications.
+        <li><b>Product Pages:</b> Price Tracker collects how often you visit saved product pages.</li>
+        <li><b>Product Data:</b> Price Tracker collects data about the products you choose to track such as prices change frequency, size, and the accuracy of that information.</li>
+        <li><b>Interaction Data:</b> Price Tracker collects information about how you use the feature such as how often you add, delete and interact with saved products, number of products you choose to track, and how you engage with messages and push notifications.
       </ul>
-      <p>If you choose to send data to Mozilla (that’s us), our <a href="https://addons.mozilla.org/en-US/firefox/addon/price-wise/privacy/">privacy policy</a> describes how we handle that data.</p>
+      <p>If you choose to send data to Mozilla (that’s us), our <a href="https://addons.mozilla.org/en-US/firefox/addon/price-tracker/privacy/">privacy policy</a> describes how we handle that data.</p>
       <h2>How do I opt-out of sending data to Mozilla?</h2>
-      <p>Price Wise uses Firefox's Telemetry system to collect data. You can opt-out of data collection by disabling Firefox Telemetry:</p>
+      <p>Price Tracker uses Firefox's Telemetry system to collect data. You can opt-out of data collection by disabling Firefox Telemetry:</p>
       <ol>
         <li>Click the menu button <img class="menu-icon" src="img/menu.svg"> and choose <i>Preferences</i>.</li>
         <li>Select the <i>Privacy & Security</i> panel.</li>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "Price Wise",
+  "name": "Price Tracker",
   "version": "$version",
   "author": "$author",
   "description": "$description",
@@ -23,7 +23,7 @@
       "16": "img/shopping_list.svg",
       "32": "img/shopping_list.svg"
     },
-    "default_title": "Price Wise",
+    "default_title": "Price Tracker",
     "default_popup": "browser_action/index.html"
   },
   "permissions": [


### PR DESCRIPTION
@javaun , @chuckharmston Requesting your approval on the following noteworthy items:
- [x] Leave the existing telemetry event category unchanged, `'extension.price_wise'` for continuity.
- [x] Remove the [Feedback survey](https://qsurvey.mozilla.com/s3/price-wise)
- Alternatives (feedback form):
  - Teon updates the URL/survey page and we update it here in the extension.
  - We leave the survey and UI as-is
- [x] Change the privacy policy URL to https://addons.mozilla.org/en-US/firefox/addon/price-tracker/privacy/. This requires changing the AMO URL to https://addons.mozilla.org/en-US/firefox/addon/price-tracker, which does not redirect from https://addons.mozilla.org/en-US/firefox/addon/price-wise .

![Screen Shot 2019-03-19 at 9 01 17 PM](https://user-images.githubusercontent.com/17437436/54658350-35332f80-4a8a-11e9-9d17-224639b6fda0.png)

![Screen Shot 2019-03-19 at 9 09 16 PM](https://user-images.githubusercontent.com/17437436/54658579-57797d00-4a8b-11e9-942f-2c2682e795b2.png)

![Screen Shot 2019-03-19 at 9 13 45 PM](https://user-images.githubusercontent.com/17437436/54658691-ee463980-4a8b-11e9-8ee1-6323f4bc7267.png)

---

Find and replace all instances of "Price Wise", "price-wise" and "price_wise" (case insensitive) with the following exceptions:
* The telemetry event category, 'extension.price_wise' for continuity.
* The survey URLs (for [feedback](https://qsurvey.mozilla.com/s3/price-wise) linked to in the popup and the now flagged off [UR study](https://qsurvey.mozilla.com/s3/Price-Wise-Research-Study)).

Note: Updating the name of the project in `package.json` and calling `npm install` also triggered adding an additional [`optional`](https://docs.npmjs.com/files/package-lock.json#optional) key in `package-lock.json` for some devDeps.