### PR TITLE
Create issue template

### DIFF
--- a/docs/issue_template.md
+++ b/docs/issue_template.md
@@ -1,0 +1,19 @@
+### Is this a feature request or a bug?
+
+
+### What is the current behavior?
+<!--
+* If this is a bug, please include the steps to take to
+  reproduce the issue including any urls, screenshots, etc.
+  as helpful.
+-->
+
+
+### What is the expected or desired behavior?
+
+
+### Version information (for bug reports)
+
+* **Firefox version**:
+* **Your OS and version**:
+* **Price Tracker extension version**:


### PR DESCRIPTION
This template will load any time a new issue is created to (hopefully) ensure some basic information is provided about the issue.

This is based on the [issue template in the `web-ext` repo](https://github.com/mozilla/web-ext/blob/master/ISSUE_TEMPLATE.md) and the [related GitHub docs](https://help.github.com/en/articles/manually-creating-a-single-issue-template-for-your-repository).